### PR TITLE
Bugfix

### DIFF
--- a/src/components/EmailResults.js
+++ b/src/components/EmailResults.js
@@ -38,6 +38,8 @@ const EmailResultsForm = ({ resultsLevel }) => {
         resultsLevel,
       }),
     }).then(() => {
+      setEmailSent(true);
+      setEmailAddress('');
       console.log('Your email message has been sent successfully');
     });
   };

--- a/src/components/EmailResults.js
+++ b/src/components/EmailResults.js
@@ -128,7 +128,7 @@ const EmailResults = ({ resultsLevel }) => (
         without spamming your inbox. Refer back when you're ready to take
         action, or use them to craft a roadmap to success!
       </p>
-      <EmailResultsForm resultsLevel={resultsLevel} />
+      <EmailResultsForm resultsLevel={resultsLevel + 1} />
     </div>
   </Section>
 );

--- a/src/components/EmailResults.js
+++ b/src/components/EmailResults.js
@@ -54,7 +54,7 @@ const EmailResultsForm = ({ resultsLevel }) => {
             onClick={() => {
               setEmailSent(false);
             }}
-            className="ml-auto text-sm uppercase font-bold text-gray-600 opacity-70"
+            className="ml-auto text-sm uppercase font-bold text-gray-600 opacity-70 cursor-hand"
           >
             Dismiss
           </button>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -61,7 +61,7 @@ const Pagination = ({ currentID, resultsPath }) => {
             'transition-[top] relative top-0 hover:-top-1'
           )}
         >
-          <LeftArrowIcon /> Previous
+          <LeftArrowIcon /> {currentID === 0 ? 'Back to home' : 'Previous'}
         </a>
       </li>
 

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -126,7 +126,9 @@ export default function ResultsPage({ level }) {
             Marsh, Carrie Hane, and Dina Lewis. Check out their findings if
             you’d like to learn more about content maturity!
           </p>
-          <ButtonOrange url="#">Learn about their research</ButtonOrange>
+          <ButtonOrange url="https://www.asaecenter.org/publications/110419-association-content-strategies-for-a-changing-world-pdf">
+            Learn about their research
+          </ButtonOrange>
         </div>
       </Section>
     </Layout>

--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -6,10 +6,9 @@ import calculateScore from '@/utils/calculateScore';
 
 const Scoreboard = () => {
   const { questions } = useContext(QuestionsContext);
-
   const score = calculateScore(questions.questions[0]);
 
-  return (
+  return process.env.NEXT_PUBLIC_LOCAL ? (
     <div
       className={classNames(
         'flex flex-col items-center gap-0 bg-slate-100 w-max p-4 rounded-lg fixed right-6 top-4 z-50 ',
@@ -20,6 +19,8 @@ const Scoreboard = () => {
       <span className="inline-block text-sm">SCORE</span>
       {score}
     </div>
+  ) : (
+    console.log(score)
   );
 };
 

--- a/src/emails/level1.tsx
+++ b/src/emails/level1.tsx
@@ -121,6 +121,11 @@ export default function Email(): ReactElement {
                 <Heading className="text-2xl my-0">{sections[4].title}</Heading>
                 <Text className="text-lg my-0">{sections[4].description}</Text>
               </div>
+
+              <div className="mb-8">
+                <Heading className="text-2xl my-0">{sections[5].title}</Heading>
+                <Text className="text-lg my-0">{sections[5].description}</Text>
+              </div>
             </Section>
 
             <Section className="bg-beige p-8 mt-8">

--- a/src/emails/level1.tsx
+++ b/src/emails/level1.tsx
@@ -47,7 +47,7 @@ export default function Email(): ReactElement {
   return (
     <Html>
       <Head>
-        <title>{title} • The Content Strategy Quiz</title>
+        <title>{`${title} • The Content Strategy Quiz`}</title>
       </Head>
       <Preview>Your content strategy result is '{title}'</Preview>
       <Tailwind

--- a/src/emails/level2.tsx
+++ b/src/emails/level2.tsx
@@ -121,6 +121,11 @@ export default function Email(): ReactElement {
                 <Heading className="text-2xl my-0">{sections[4].title}</Heading>
                 <Text className="text-lg my-0">{sections[4].description}</Text>
               </div>
+
+              <div className="mb-8">
+                <Heading className="text-2xl my-0">{sections[5].title}</Heading>
+                <Text className="text-lg my-0">{sections[5].description}</Text>
+              </div>
             </Section>
           </Container>
 

--- a/src/emails/level2.tsx
+++ b/src/emails/level2.tsx
@@ -47,7 +47,7 @@ export default function Email(): ReactElement {
   return (
     <Html>
       <Head>
-        <title>{title} • The Content Strategy Quiz</title>
+        <title>{`${title} • The Content Strategy Quiz`}</title>
       </Head>
       <Preview>Your content strategy result is '{title}'</Preview>
       <Tailwind

--- a/src/emails/level3.tsx
+++ b/src/emails/level3.tsx
@@ -121,6 +121,11 @@ export default function Email(): ReactElement {
                 <Heading className="text-2xl my-0">{sections[4].title}</Heading>
                 <Text className="text-lg my-0">{sections[4].description}</Text>
               </div>
+
+              <div className="mb-8">
+                <Heading className="text-2xl my-0">{sections[5].title}</Heading>
+                <Text className="text-lg my-0">{sections[5].description}</Text>
+              </div>
             </Section>
           </Container>
 

--- a/src/emails/level3.tsx
+++ b/src/emails/level3.tsx
@@ -47,7 +47,7 @@ export default function Email(): ReactElement {
   return (
     <Html>
       <Head>
-        <title>{title} • The Content Strategy Quiz</title>
+        <title>{`${title} • The Content Strategy Quiz`}</title>
       </Head>
       <Preview>Your content strategy result is '{title}'</Preview>
       <Tailwind

--- a/src/emails/level4.tsx
+++ b/src/emails/level4.tsx
@@ -121,6 +121,11 @@ export default function Email(): ReactElement {
                 <Heading className="text-2xl my-0">{sections[4].title}</Heading>
                 <Text className="text-lg my-0">{sections[4].description}</Text>
               </div>
+
+              <div className="mb-8">
+                <Heading className="text-2xl my-0">{sections[5].title}</Heading>
+                <Text className="text-lg my-0">{sections[5].description}</Text>
+              </div>
             </Section>
           </Container>
 

--- a/src/emails/level4.tsx
+++ b/src/emails/level4.tsx
@@ -47,7 +47,7 @@ export default function Email(): ReactElement {
   return (
     <Html>
       <Head>
-        <title>{title} • The Content Strategy Quiz</title>
+        <title>{`${title} • The Content Strategy Quiz`}</title>
       </Head>
       <Preview>Your content strategy result is '{title}'</Preview>
       <Tailwind

--- a/src/emails/level5.tsx
+++ b/src/emails/level5.tsx
@@ -47,7 +47,7 @@ export default function Email(): ReactElement {
   return (
     <Html>
       <Head>
-        <title>{title} • The Content Strategy Quiz</title>
+        <title>{`${title} • The Content Strategy Quiz`}</title>
       </Head>
       <Preview>Your content strategy result is '{title}'</Preview>
       <Tailwind


### PR DESCRIPTION
This PR fixes the following bugs:
* The scorecard should only appear in the upper right hand corner when the following environment variable is set: `NEXT_PUBLIC_LOCAL=true`. This will need to be tested locally because the Netlify deploy process applies this variable to all branches except `main`.
* On the [results pages](https://deploy-preview-21--content-maturity-quiz.netlify.app/results/managed), under "Take your results with you", when you enter an email and click "Send me the results" you should get a message that the email has been sent.
* When you send yourself results, you should now get the correct level results emailed to you.
* On the [first question page](https://deploy-preview-21--content-maturity-quiz.netlify.app/1), the back button's label should be "Back to Home". (On the other question pages the back button label remains "previous")
* On the [results pages](https://deploy-preview-21--content-maturity-quiz.netlify.app/results/managed), at the bottom, under "Credit where credit is due", the button should link to https://www.asaecenter.org/publications/110419-association-content-strategies-for-a-changing-world-pdf.
* Update emails for level 1 and 2 to add more copy.
